### PR TITLE
fix tests and some deprecations for julia 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,5 @@
 julia 0.4
 Reexport
 Iterators
+DataStructures
 Compat 0.8.4

--- a/src/DBAPIBase.jl
+++ b/src/DBAPIBase.jl
@@ -31,22 +31,22 @@ import Base: connect, close, getindex, isopen, show, start, next, done, length, 
 
 import Iterators: imap
 
-abstract DatabaseInterface
-abstract DatabaseError{T<:DatabaseInterface} <: Exception
-abstract DatabaseConnection{T<:DatabaseInterface}
-abstract DatabaseCursor{T<:DatabaseInterface}
-abstract FixedLengthDatabaseCursor{T} <: DatabaseCursor{T}
+abstract type DatabaseInterface end
+abstract type DatabaseError{T<:DatabaseInterface} <: Exception  end
+abstract type DatabaseConnection{T<:DatabaseInterface} end
+abstract type DatabaseCursor{T<:DatabaseInterface} end
+abstract type FixedLengthDatabaseCursor{T} <: DatabaseCursor{T} end
 Base.linearindexing(::Type{FixedLengthDatabaseCursor}) = Base.LinearSlow()
 Base.ndims(cursor::FixedLengthDatabaseCursor) = 2
 
 "A database query."
-abstract DatabaseQuery
+abstract type DatabaseQuery end
 
 "A database query which includes a set of parameters."
-abstract ParameterQuery <: DatabaseQuery
+abstract type ParameterQuery <: DatabaseQuery end
 
 "A database query which includes a set of parameter sets."
-abstract MultiparameterQuery <: ParameterQuery
+abstract type MultiparameterQuery <: ParameterQuery end
 
 "A database query stored in a string."
 immutable SimpleStringQuery{T<:AbstractString} <: DatabaseQuery
@@ -65,7 +65,7 @@ immutable StringMultiparameterQuery{T<:AbstractString, S} <: MultiparameterQuery
     param_list::S
 end
 
-typealias StringQuery Union{
+const StringQuery = Union{
     SimpleStringQuery, StringParameterQuery, StringMultiparameterQuery
 }
 
@@ -407,7 +407,7 @@ A terrible hack to make the fetchintoarray! signature work.
 
 See https://github.com/JuliaLang/julia/issues/13156#issuecomment-140618981
 """
-typealias AssociativeVK{V, K} Associative{K, V}
+const AssociativeVK{V, K} = Associative{K, V}
 
 index_return_type(a::Associative) = valtype(a)
 index_return_type(a::Any) = eltype(a)
@@ -576,7 +576,7 @@ function fetchintocolumns!{T<:DatabaseInterface, U<:Union{AbstractArray, Associa
     throw(NotSupportedError{T}())
 end
 
-typealias Orientation Union{Val{:rows}, Val{:columns}, Val{:array}}
+const Orientation = Union{Val{:rows}, Val{:columns}, Val{:array}}
 
 immutable DatabaseFetcher{O<:Orientation, T<:DatabaseInterface, U<:Union{AbstractArray, Associative}}
     orientation::O

--- a/src/arrays.jl
+++ b/src/arrays.jl
@@ -7,7 +7,7 @@ import Compat.view
 
 ### Underlying column data structures
 
-abstract AbstractColumn{T}
+abstract type AbstractColumn{T} end
 
 immutable Column{T} <: AbstractColumn{T}
     name::Symbol

--- a/test/arrays.jl
+++ b/test/arrays.jl
@@ -1,7 +1,7 @@
 module TestColumnarArrayInterface
 
 using FactCheck
-import Base.Collections: PriorityQueue
+import DataStructures: PriorityQueue
 
 import Iterators: chain
 

--- a/test/failedinterface.jl
+++ b/test/failedinterface.jl
@@ -2,7 +2,7 @@ module FailedInterface
 
 import DBAPI
 using FactCheck
-import Base.Collections: PriorityQueue
+import DataStructures: PriorityQueue
 
 type BadInterface <: DBAPI.DatabaseInterface end
 type BadConnection <: DBAPI.DatabaseConnection{BadInterface} end


### PR DESCRIPTION
Added DataStructures to REQUIRES, because PriorityQueue was moved there from Base.